### PR TITLE
initial version of okteto's dev envs

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,5 @@
+cat << EOF
+Welcome to your development environment. Happy coding!
+EOF
+
+export PS1="\[\e[32m\]okteto\[\e[m\]> "

--- a/desk/Dockerfile
+++ b/desk/Dockerfile
@@ -1,0 +1,31 @@
+FROM docker:18.09.1 AS docker
+
+FROM ubuntu:18.04
+
+# install docker client
+COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker
+
+# install golang & ruby
+RUN apt-get -y update
+RUN apt-get install -y build-essential git-core curl zlib1g-dev
+RUN apt-get install -y golang-go
+RUN apt-get install -y ruby-full && gem install bundler 
+
+# install nodejs 10 and yarn
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && apt-get install -y nodejs yarn
+
+# install docker-compose
+RUN curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+RUN chmod +x /usr/local/bin/docker-compose
+
+# install kubectl
+RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.2'
+
+services:
+  desk:
+    build:
+      context: .
+      dockerfile: desk/Dockerfile
+    image: okteto/desk:0.1.3
+  golang:
+    build:
+      context: .
+      dockerfile: golang/Dockerfile
+    image: okteto/golang:1
+  gradle:
+    build:
+      context: .
+      dockerfile: gradle/Dockerfile
+    image: okteto/gradle:5.1-jdk11
+  node:
+    build:
+      context: .
+      dockerfile: node/Dockerfile
+    image: okteto/node:10
+  python:
+    build:
+      context: .
+      dockerfile: python/Dockerfile
+    image: okteto/python:3
+  ruby:
+    build:
+      context: .
+      dockerfile: ruby/Dockerfile
+    image: okteto/ruby:2

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.12
+WORKDIR /app
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+RUN go get github.com/codegangsta/gin
+
+CMD ["bash"]

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -2,6 +2,6 @@ FROM gradle:5.1-jdk11
 WORKDIR /home/gradle
 
 # setup okteto message
-COPY bashrc /root/.bashrc
+COPY bashrc /home/gradle/.bashrc
 
 CMD ["bash"]

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,0 +1,7 @@
+FROM gradle:5.1-jdk11
+WORKDIR /home/gradle
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+CMD ["bash"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:10
+WORKDIR /usr/src/app
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+CMD ["bash"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+WORKDIR /usr/src/app
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+CMD ["bash"]

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2
+WORKDIR /usr/src/app
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+CMD ["bash"]


### PR DESCRIPTION
The idea with this is to keep a basic version of dev environments here. At the least:
- Build based on the default image
- Defaults to bash, with a welcome message and the `okteto >` prefix

In the near future, we could install extra dev tools (e.g. debuggers)