### PR TITLE
docker image with okteto binary

### DIFF
--- a/bin/Dockerfile
+++ b/bin/Dockerfile
@@ -42,3 +42,10 @@ FROM opensource as cloud
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=builder /usr/local/bin/okteto /usr/local/bin/okteto
 COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm
+
+FROM alpine:3 as okteto
+
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=builder /usr/local/bin/okteto /usr/local/bin/okteto
+COPY --from=builder /usr/local/bin/helm /usr/local/bin/helm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,12 @@
 version: '3.7'
 
 services:
+  okteto:
+    image: okteto/okteto:1.8.1
+    build:
+      context: .
+      target: okteto
+      dockerfile: bin/Dockerfile
   bin:
     image: okteto/bin:1.1.10
     build:
@@ -8,7 +14,7 @@ services:
       target: opensource
       dockerfile: bin/Dockerfile
   bin-cloud:
-    image: okteto/bin:1.1.10-cloud
+    image: okteto/bin:1.1.110-cloud
     build:
       context: .
       target: cloud

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       target: opensource
       dockerfile: bin/Dockerfile
   bin-cloud:
-    image: okteto/bin:1.1.110-cloud
+    image: okteto/bin:1.1.10-cloud
     build:
       context: .
       target: cloud


### PR DESCRIPTION
We can use this image as base for the github actions, gitlab review apps, or in case someone wants to run okteto from a dockerfile instead of installing locally (haven't tried up, but it might work).

Separate from `bin-cloud` so that we can use `alpine`, and to use `okteto:okteto` and the CLI version as the tag.