### PR TITLE
Add namespace and current folder to the default prompt

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -2,4 +2,4 @@ cat << EOF
 Welcome to your development environment. Happy coding!
 EOF
 
-export PS1="\[\e[32m\]okteto\[\e[m\]> "
+export PS1="\[\e[32m\]\${OKTETO_NAMESPACE:-okteto} \w\[\e[m\]> "


### PR DESCRIPTION
Several users complained about the default prompt now showing the current folder.
Others complained about not having info about where the terminal is running.

I will add "OKTEO_NAMESPACE" on every "okteto up" execution.