### PR TITLE
added OpenFaaS deno-http-template

### DIFF
--- a/openfaas/deno-http-template/Dockerfile
+++ b/openfaas/deno-http-template/Dockerfile
@@ -1,0 +1,17 @@
+FROM austinrivas/deno-http-base:stable
+
+WORKDIR ${FUNC_HOME_DIR}
+
+RUN chown fnUser:fnGroup -R /usr/local \
+    && apk --no-cache add bash \
+    && echo 'Welcome to your development environment. Happy coding!' > /etc/mod \
+    && echo 'export PS1="\[\e[32m\]okteto\[\e[m\]> "' >> .bashrc
+
+USER fnUser
+
+ADD --chown=fnUser:fnGroup https://raw.githubusercontent.com/austinrivas/deno-http-template/master/template/deno-http/main.ts .
+ADD --chown=fnUser:fnGroup https://raw.githubusercontent.com/austinrivas/deno-http-template/master/template/deno-http/function/handler.ts ./function
+
+RUN deno cache function/handler.ts main.ts
+
+CMD ["fwatchdog"]

--- a/openfaas/deno-http-template/okteto.yml
+++ b/openfaas/deno-http-template/okteto.yml
@@ -1,0 +1,29 @@
+# The name tells Okteto to replace the function named 'hello' with the dev environment
+name: deno-hello       
+labels:
+  faas_function: deno-hello
+image: austinrivas/deno-http-okteto:stable
+command:
+  - bash
+workdir: /home/app
+mountpath: /home/app/function
+persistentVolume:
+  enabled: true
+volumes:
+  # This makes the deno cache persistent across development environments
+  - /home/app/.cache/
+securityContext:
+  # the user and group that OpenFaaS functions run as
+  runAsUser:  12000
+  runAsGroup: 12000
+  fsGroup:    12000
+  capabilities:
+    add:
+    # enables us to run the debugger inside the pod
+    - SYS_PTRACE
+environment:
+  # overrides the one set by openfaas, enabling hot reload
+  - fprocess=deno run --allow-net --allow-env main.ts
+forward:
+  - 8080:8080
+  - 2345:2345


### PR DESCRIPTION
The Dockerfile is pretty minimal because it extends a base image.

You can checkout what the base is doing [here](https://github.com/austinrivas/deno-http-template/blob/master/deno-http-base/Dockerfile)

[Here](https://github.com/austinrivas/openfaas_deno_func) is an example function you can test this with.

The [okteto.yml](https://github.com/austinrivas/openfaas_deno_func/blob/master/function/okteto.yml) seems to work fine.