### PR TITLE
Unify workdir in our dev images

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,5 +1,10 @@
 FROM ubuntu:18.04
 
+WORKDIR /usr/src/app
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
 # add keys and install golang, ruby and nodejs
 RUN apt-get -y update && \
     apt-get install -y curl && \
@@ -13,8 +18,6 @@ RUN apt-get -y update && \
     gem install bundler && \
     apt-get clean -y && apt-get autoremove -y
     
-# setup okteto message
 RUN rm /etc/update-motd.d/*
-COPY bashrc /root/.bashrc
 
 CMD ["bash"]

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /root/
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -1,11 +1,15 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as base
+
 RUN apt-get update && apt-get install -y unzip
 RUN curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l /root/vsdbg
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
-COPY --from=base /root/vsdbg /usr/local/bin/vsdbg
+WORKDIR /src
+
 # setup okteto message
 COPY bashrc /root/.bashrc
+
+COPY --from=base /root/vsdbg /usr/local/bin/vsdbg
 
 CMD ["bash"]

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15-buster
 
-WORKDIR /app
+WORKDIR /src
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15-buster
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,5 +1,7 @@
 FROM gradle:6.5
 
+WORKDIR /src
+
 # setup okteto message
 COPY bashrc /home/gradle/.bashrc
 

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -1,6 +1,6 @@
 FROM gradle:6.5
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /home/gradle/.bashrc

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,5 +1,7 @@
 FROM maven:3-openjdk
 
+WORKDIR /src
+
 # setup okteto message
 COPY bashrc /root/.bashrc
 

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3-openjdk
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12
 
-WORKDIR /app
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,5 +1,9 @@
 FROM php:7
-WORKDIR /okteto
+
+WORKDIR /src
+
+# setup okteto message
+COPY bashrc /root/.bashrc
 
 RUN apt-get update && apt-get install -y zip git libzip-dev && \ 
   pecl install xdebug && echo 'zend_extension="xdebug.so"' > /usr/local/etc/php/conf.d/xdebug.ini && \
@@ -12,8 +16,6 @@ RUN apt-get update && apt-get install -y zip git libzip-dev && \
 
 COPY php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
-# setup okteto message
-COPY bashrc /root/.bashrc
-
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.composer/vendor/bin/:/okteto/vendor/bin/
+
 CMD ["bash"]

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3
-WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y zip git
+WORKDIR /src
 
 # setup okteto message
 COPY bashrc /root/.bashrc
+
+RUN apt-get update && apt-get install -y zip git
 
 CMD ["bash"]

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,9 +1,10 @@
 FROM ruby:2
-WORKDIR /usr/src/app
 
-RUN gem install bundler
+WORKDIR /src
 
 # setup okteto message
 COPY bashrc /root/.bashrc
+
+RUN gem install bundler
 
 CMD ["bash"]

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,5 +1,7 @@
 FROM rust:1
 
+WORKDIR /src
+
 # setup okteto message
 COPY bashrc /root/.bashrc
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1
 
-WORKDIR /src
+WORKDIR /usr/src/app
 
 # setup okteto message
 COPY bashrc /root/.bashrc


### PR DESCRIPTION
It is very confusing that, when using our dev images, you need to define:

```
sync:
  - .:/app
```

or 

```
sync:
  - .:/okteto
```

or 

```
sync:
  - .:/usr/src/app
```

depending on the dev image you are using.

