### PR TITLE
add dockerfile for golang 1.14

### DIFF
--- a/golang/1.14/Dockerfile
+++ b/golang/1.14/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.14-buster
+
+WORKDIR /usr/src/app
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+RUN go get github.com/codegangsta/gin && \
+    go get -u github.com/go-delve/delve/cmd/dlv && \
+    go get -u golang.org/x/tools/gopls
+
+CMD ["bash"]


### PR DESCRIPTION
putting it for historical reasons, since some projects still need it.