### PR TITLE
updates maven dockerfile to use newly released LTS jdk 17 version.

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION=3
-FROM maven:${VERSION}-openjdk
+FROM maven:${VERSION}-openjdk-17
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
As per https://github.com/okteto/okteto/issues/1777, this PR simply updates the maven docker image to use the newly released jdk 17 version.