### PR TITLE
add node16 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,13 @@ services:
     build:
       context: .
       dockerfile: maven/Dockerfile
+  node16:
+    image: okteto/node:16
+    build:
+      context: .
+      dockerfile: node/Dockerfile
+      args:
+        VERSION: 16
   node14:
     image: okteto/node:14
     build:


### PR DESCRIPTION
Creates an okteto:node:16 image.

I'm actually not sure if this is enough, as for instance on the node:14 image on dockerhub it says "ENV NODE_VERSION=14.18.1", while all I can find here is a plain "Version: 14".

For the node:16 image I would actually prefer the current LTS version: v16.13.0, but I wasn't sure if I should define this here.