### PR TITLE
Fix:  --push command not recognised, and "no target error""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
 .PHONY: build push
 
 build: 
-	docker buildx bake \
-		--push \
-		--set node*.platform=linux/amd64,linux/arm64 \  
-		--set golang*.platform=linux/amd64,linux/arm64 \
-		--set python*.platform=linux/amd64,linux/arm64 \
-		--set ruby.platform=linux/amd64,linux/arm64 \
-		--set php.platform=linux/amd64,linux/arm64 \
-		--set maven.platform=linux/amd64,linux/arm64 \
-		--set dotnetcore*.platform=linux/amd64,linux/arm64
+	docker buildx bake -f docker-compose.yml \
+	--set=node*.platform=linux/amd64,linux/arm64 \
+	--set=golang*.platform=linux/amd64,linux/arm64 \
+	--set=python*.platform=linux/amd64,linux/arm64 \
+	--set=ruby.platform=linux/amd64,linux/arm64 \
+	--set=php.platform=linux/amd64,linux/arm64 \
+	--set=maven.platform=linux/amd64,linux/arm64 \
+	--set=dotnetcore*.platform=linux/amd64,linux/arm64 \
+	--set=*.output=type=docker \
+	--set=*.output=type=registry
 
 build.dev: 
-	docker buildx bake \
-		--push \
-		--set dev.platform=linux/amd64,linux/arm64
+	docker buildx bake -f docker-compose.dev.yml \
+		--set=*.output=type=docker \
+		--set=*.output="type=registry" \
+		--set=dev.platform=linux/amd64,linux/arm64
 
 build.rust: 
-	docker buildx bake \
-		--push \
+	docker buildx bake -f docker-compose.rust.yml \
+		--set=*.output=type=docker \
+		--set=*.output="type=registry" \
 		--set rust.platform=linux/amd64,linux/arm64


### PR DESCRIPTION
When I pushed the last commit into the #93 PR it seems in some versions of docker buildx there are some incompatibilities, so I flattened the command also fixing some bugs, please check this version in CircleCI before. 

In local I have an error of buildx nonsupporting multi arch, I think CircleCI should not have this issue, testing it would  let me troubleshoot.

Also, It seems dotnetcore 6.0 version is no more available.