### PR TITLE
Adding go versions 1.18 and 1.19 dev images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Development Containers for Okteto
 
-When you run `okteto up` the container running your application is replaced by a development container that contains your development tools (e.g. maven and jdk, or npm, python, go compiler, debuggers, etc). 
+When you run `okteto up` the container running your application is replaced by a development container that contains your development tools (e.g. maven and jdk, or npm, python, go compiler, debuggers, etc).
 
-The development container can be any docker image. More information about development containers, and how to build your own [is available here](https://okteto.com/docs/reference/development-environment/index.html). 
+The development container can be any docker image. More information about development containers, and how to build your own [is available here](https://okteto.com/docs/reference/development-environment/index.html).
 
 The development containers on this list are maintained by the Okteto team to help you get started:
 
-## General Use 
+## General Use
 | Language/Stack    | Docker Image |
 | ----------------- |------------- |
 | dotnetcore 6.0   | [okteto/dotnetcore:6](dotnetcore/Dockerfile)|
-| golang 1.17       | [okteto/golang:1](golang/Dockerfile)|
+| golang 1.19       | [okteto/golang:1](golang/Dockerfile)|
 | jdk 8, Gradle 6.5  | [okteto/gradle:6.5](gradle/Dockerfile)|
 | jdk 11, Maven 3    | [okteto/maven:3-openjdk](maven/Dockerfile)|
 | node 16           | [okteto/node:16](node/Dockerfile)|

--- a/docker-compose.golang.yml
+++ b/docker-compose.golang.yml
@@ -7,7 +7,21 @@ services:
       context: .
       dockerfile: golang/Dockerfile
       args:
-        VERSION: 1.17
+        VERSION: 1.19
+  golang1.19:
+    image: okteto/golang:1.19
+    build:
+      context: .
+      dockerfile: golang/Dockerfile
+      args:
+        VERSION: 1.19
+  golang1.18:
+    image: okteto/golang:1.18
+    build:
+      context: .
+      dockerfile: golang/Dockerfile
+      args:
+        VERSION: 1.18
   golang1.17:
     image: okteto/golang:1.17
     build:

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=1.17
+ARG VERSION=1.19
 FROM golang:$VERSION-buster
 
 WORKDIR /usr/src/app

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=1.19
+ARG VERSION=1.16
 FROM golang:$VERSION-buster
 
 WORKDIR /usr/src/app
@@ -6,9 +6,9 @@ WORKDIR /usr/src/app
 # setup okteto message
 COPY bashrc /root/.bashrc
 
-RUN go get github.com/codegangsta/gin && \
-    go get github.com/go-delve/delve/cmd/dlv && \
-    go get golang.org/x/tools/gopls && \
+RUN go install github.com/codegangsta/gin@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@latest && \
+    go install golang.org/x/tools/gopls@latest && \
     curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
 
 CMD ["bash"]

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=1.16
+ARG VERSION=1.19
 FROM golang:$VERSION-buster
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
The golang:1 image will now be based off of 1.19 instead of 1.17.
Also, images golang:1.18 and golang:1.19 will be generated with
their respective versions.