### PR TITLE
Upgrade go to 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The development containers on this list are maintained by the Okteto team to hel
 | Language/Stack    | Docker Image |
 | ----------------- |------------- |
 | dotnetcore 6.0   | [okteto/dotnetcore:6](dotnetcore/Dockerfile)|
-| golang 1.17       | [okteto/golang:1](golang/Dockerfile)|
+| golang 1.18       | [okteto/golang:1](golang/Dockerfile)|
 | jdk 8, Gradle 6.5  | [okteto/gradle:6.5](gradle/Dockerfile)|
 | jdk 11, Maven 3    | [okteto/maven:3-openjdk](maven/Dockerfile)|
 | node 16           | [okteto/node:16](node/Dockerfile)|

--- a/docker-compose.golang.yml
+++ b/docker-compose.golang.yml
@@ -7,7 +7,16 @@ services:
       context: .
       dockerfile: golang/Dockerfile
       args:
-        VERSION: 1.17
+        VERSION: 1.18
+
+
+  golang1.18:
+    image: okteto/golang:1.18
+    build:
+      context: .
+      dockerfile: golang/Dockerfile
+      args:
+        VERSION: 1.18
   golang1.17:
     image: okteto/golang:1.17
     build:

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=1.17
+ARG VERSION=1.18
 FROM golang:$VERSION-buster
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
We're currently using `go 1.17` which was released a year ago and is [no longer supported](https://endoflife.date/go)
`1.18` was released 5 months ago and is battle tested, in contrast to `1.19` which was released a week ago.
