### PR TITLE
use go install to build images

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /usr/src/app
 # setup okteto message
 COPY bashrc /root/.bashrc
 
-RUN go get github.com/codegangsta/gin && \
-    go get github.com/go-delve/delve/cmd/dlv && \
-    go get golang.org/x/tools/gopls && \
+RUN go install github.com/codegangsta/gin && \
+    go install github.com/go-delve/delve/cmd/dlv && \
+    go install golang.org/x/tools/gopls && \
     curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
 
 CMD ["bash"]

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /usr/src/app
 # setup okteto message
 COPY bashrc /root/.bashrc
 
-RUN go install github.com/codegangsta/gin && \
-    go install github.com/go-delve/delve/cmd/dlv && \
-    go install golang.org/x/tools/gopls && \
+RUN go install github.com/codegangsta/gin@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@latest && \
+    go install golang.org/x/tools/gopls@latest && \
     curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
 
 CMD ["bash"]


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Use go install instead of go get to avoid build issues