### PR TITLE
Add support to Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ The development container can be any docker image. More information about develo
 The development containers on this list are maintained by the Okteto team to help you get started:
 
 ## General Use
-| Language/Stack    | Docker Image |
-| ----------------- |------------- |
-| dotnetcore 6.0   | [okteto/dotnetcore:6](dotnetcore/Dockerfile)|
-| golang 1.19       | [okteto/golang:1](golang/Dockerfile)|
-| jdk 8, Gradle 6.5  | [okteto/gradle:6.5](gradle/Dockerfile)|
-| jdk 11, Maven 3    | [okteto/maven:3-openjdk](maven/Dockerfile)|
-| node 16           | [okteto/node:16](node/Dockerfile)|
-| php 7      | [okteto/php:7](php/Dockerfile)|
-| python 3      | [okteto/python:3](python/Dockerfile)|
-| ruby 2      | [okteto/ruby:2](ruby/Dockerfile)|
-| rust      | [okteto/rust:1](rust/Dockerfile)|
+| Language/Stack    | Docker Image                                 |
+|-------------------|----------------------------------------------|
+| dotnetcore 6.0    | [okteto/dotnetcore:6](dotnetcore/Dockerfile) |
+| golang 1.19       | [okteto/golang:1](golang/Dockerfile)         |
+| jdk 8, Gradle 6.5 | [okteto/gradle:6.5](gradle/Dockerfile)       |
+| jdk 11, Maven 3   | [okteto/maven:3-openjdk](maven/Dockerfile)   |
+| node 18           | [okteto/node:18](node/Dockerfile)            |
+| php 7             | [okteto/php:7](php/Dockerfile)               |
+| python 3          | [okteto/python:3](python/Dockerfile)         |
+| ruby 2            | [okteto/ruby:2](ruby/Dockerfile)             |
+| rust              | [okteto/rust:1](rust/Dockerfile)             |
 
 # Contributions
 

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -1,6 +1,13 @@
 version: '3.7'
 
 services:
+  node18:
+    image: okteto/node:18
+    build:
+      context: .
+      dockerfile: node/Dockerfile
+      args:
+        VERSION: 18
   node16:
     image: okteto/node:16
     build:


### PR DESCRIPTION
First step to fix https://github.com/okteto/app/issues/5082.

# Why

So we are using latest LTS version of Node.

# What

Adding support to Node 18 with new image.
Updated README accordingly.