### PR TITLE
pin air version in golang

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -9,6 +9,6 @@ COPY bashrc /root/.bashrc
 RUN go install github.com/codegangsta/gin@latest && \
     go install github.com/go-delve/delve/cmd/dlv@latest && \
     go install golang.org/x/tools/gopls@latest && \
-    curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
+    curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin -d v1.42.0
 
 CMD ["bash"]


### PR DESCRIPTION
When we update golang to 1.20 we inadvertently updated to the latest version of [air](https://github.com/cosmtrek/air) which seems to have some issues and breaks our `make watch` command for dev environments:

```
okteto:api app> make watch
air
air: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by air)
air: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by air)
```

Fix is to pin `air` to the latest know version that works will all go version: `1.42.0`. Latest version is `1.44.0`. Before this we were probably quite behind (whatever version air had when we released `okteto.golang:1` for the last time.