### PR TITLE
Add support to Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The development containers on this list are maintained by the Okteto team to hel
 | golang 1.21       | [okteto/golang:1](golang/Dockerfile)         |
 | jdk 17, Gradle 8.2 | [okteto/gradle:6.5](gradle/Dockerfile)       |
 | jdk 17, Maven 3   | [okteto/maven:3-openjdk](maven/Dockerfile)   |
-| node 18           | [okteto/node:18](node/Dockerfile)            |
+| node 20           | [okteto/node:20](node/Dockerfile)            |
 | php 7             | [okteto/php:7](php/Dockerfile)               |
 | python 3          | [okteto/python:3](python/Dockerfile)         |
 | ruby 2            | [okteto/ruby:2](ruby/Dockerfile)             |

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -1,6 +1,13 @@
 version: '3.7'
 
 services:
+  node20:
+    image: okteto/node:20
+    build:
+      context: .
+      dockerfile: node/Dockerfile
+      args:
+        VERSION: 20
   node18:
     image: okteto/node:18
     build:


### PR DESCRIPTION
Added support to NodeJS v20 and updated the README.

I noticed that several old Node versions were removed in [this PR](https://github.com/okteto/devenv/pull/106/files#diff-d5538c933878c1c065fc7a041befbffabc59b3f60c029245232ebcfbaad1476f), but I don't have a clear understanding on when is safe to remove them, after taking a look to the conversation in [this other PR](https://github.com/okteto/devenv/pull/102#issuecomment-1335258948).

Should we now remove some of the old node images specified in the `docker-compose.node.yml` image?