### PR TITLE
Update docker-compose.dotnet.yml to build dotnetcore 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The development containers on this list are maintained by the Okteto team to hel
 ## General Use
 | Language/Stack    | Docker Image                                 |
 |-------------------|----------------------------------------------|
-| dotnetcore 6.0    | [okteto/dotnetcore:6](dotnetcore/Dockerfile) |
+| dotnetcore 8.0    | [okteto/dotnetcore:8](dotnetcore/Dockerfile) |
 | golang 1.21       | [okteto/golang:1](golang/Dockerfile)         |
 | jdk 17, Gradle 8.2 | [okteto/gradle:6.5](gradle/Dockerfile)       |
 | jdk 17, Maven 3   | [okteto/maven:3-openjdk](maven/Dockerfile)   |

--- a/docker-compose.dotnet.yml
+++ b/docker-compose.dotnet.yml
@@ -15,5 +15,12 @@ services:
       dockerfile: dotnetcore/Dockerfile
       args:
         VERSION: "6.0"
+  dotnetcore8:
+    image: okteto/dotnetcore:8
+    build:
+      context: .
+      dockerfile: dotnetcore/Dockerfile
+      args:
+        VERSION: "8.0"
 
   

--- a/docker-compose.dotnet.yml
+++ b/docker-compose.dotnet.yml
@@ -1,13 +1,6 @@
 version: '3.7'
 
 services:
-  dotnetcore3:
-    image: okteto/dotnetcore:3
-    build:
-      context: .
-      dockerfile: dotnetcore/Dockerfile
-      args:
-        VERSION: "3.1"
   dotnetcore6:
     image: okteto/dotnetcore:6
     build:

--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=6.0
+ARG VERSION=8.0
 FROM mcr.microsoft.com/dotnet/sdk:$VERSION as base
 
 RUN apt-get update && apt-get install -y unzip


### PR DESCRIPTION
Removing dotnet 3.1 since it's 3+ years old
Adding dotnet 8.0 since it's the new one