### PR TITLE
Helm Dev Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ build:
 		--set "*.platform=linux/amd64"
 	echo "Building dotnet" && docker buildx bake -f docker-compose.dotnet.yml \
 		--set "*.platform=linux/amd64"
+	echo "Building helm" && docker buildx bake -f docker-compose.helm.yml \
+		--set "*.platform=linux/amd64"
 
 push:
 	docker buildx bake -f docker-compose.dev.yml \
@@ -41,6 +43,9 @@ push:
 		--push \
 		--set "*.platform=linux/amd64"
 	docker buildx bake -f docker-compose.dotnet.yml \
+		--push \
+		--set "*.platform=linux/amd64"
+	docker buildx bake -f docker-compose.helm.yml \
 		--push \
 		--set "*.platform=linux/amd64"
 

--- a/docker-compose.helm.yml
+++ b/docker-compose.helm.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  helm3.14.4:
+    image: okteto/helm:3.14.4
+    build:
+      context: .
+      dockerfile: helm/Dockerfile
+      args:
+        VERSION: "3.14.4"
+        PLUGIN_UNITTEST_VERSION: "0.3.0"

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.22-bookworm
+
+ARG VERSION=3.14.4
+ARG PLUGIN_UNITTEST_VERSION=0.3.0
+
+RUN curl -sLf --retry 3 -o helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz && \
+    mkdir -p helm && tar -C helm -xf helm.tar.gz && \
+    cp helm/linux-amd64/helm /usr/local/bin/helm && \
+    chmod +x /usr/local/bin/helm && \
+    /usr/local/bin/helm version
+
+RUN helm plugin install https://github.com/helm-unittest/helm-unittest --version v${PLUGIN_UNITTEST_VERSION}
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
Related to https://github.com/okteto/app/pull/8253#discussion_r1658480423

In order to run okteto test at ci for the chart, we need an image that includes helm and unittest plugin.
Currently this is coupled to the okteto cli image.