### PR TITLE
update helm to 3.16.2 and unittest to 0.6.3

### DIFF
--- a/docker-compose.helm.yml
+++ b/docker-compose.helm.yml
@@ -2,10 +2,10 @@ version: '3.7'
 
 services:
   helm3.14.4:
-    image: okteto/helm:3.14.4
+    image: okteto/helm:3.16.2
     build:
       context: .
       dockerfile: helm/Dockerfile
       args:
-        VERSION: "3.14.4"
-        PLUGIN_UNITTEST_VERSION: "0.3.0"
+        VERSION: "3.16.2"
+        PLUGIN_UNITTEST_VERSION: "0.6.3"

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22-bookworm
 
-ARG VERSION=3.14.4
-ARG PLUGIN_UNITTEST_VERSION=0.3.0
+ARG VERSION=3.16.2
+ARG PLUGIN_UNITTEST_VERSION=0.6.3
 
 RUN curl -sLf --retry 3 -o helm.tar.gz https://get.helm.sh/helm-v${VERSION}-linux-amd64.tar.gz && \
     mkdir -p helm && tar -C helm -xf helm.tar.gz && \


### PR DESCRIPTION
needed to start using newer features of the helm unittest plugin