### PR TITLE
update devenv to 1.25

### DIFF
--- a/docker-compose.golang.yml
+++ b/docker-compose.golang.yml
@@ -1,18 +1,16 @@
-version: "3.7"
-
 services:
   golang1:
     build:
       context: .
       dockerfile: golang/Dockerfile
       args:
-        VERSION: "1.24.11"
-        CONTROLLER_GEN_VERSION: "v0.17.3"
-        # Need to override this because newer versions of gopls don't work with this golang version
-        GOPLS_VERSION: "v0.20.0"
+        VERSION: "1.25.5"
+        CONTROLLER_GEN_VERSION: "v0.20.0"
       tags:
         - okteto/golang:1
+        - okteto/golang:1.25
         - ghcr.io/okteto/golang:1
+        - ghcr.io/okteto/golang:1.25
 
   golang1.24:
     build:
@@ -21,24 +19,8 @@ services:
       args:
         VERSION: "1.24.11"
         CONTROLLER_GEN_VERSION: "v0.17.3"
-        # Need to override this because newer versions of gopls don't work with this golang version
         GOPLS_VERSION: "v0.20.0"
+        DLV_VERSION: "v1.26.0"
       tags:
         - okteto/golang:1.24
         - ghcr.io/okteto/golang:1.24
-
-  golang1.23:
-    build:
-      context: .
-      dockerfile: golang/Dockerfile
-      args:
-        VERSION: "1.23.12"
-        # Need to override this because newer versions of gopls don't work with this golang version
-        GOPLS_VERSION: "v0.17.1"
-        # Need to override this because newer versions of controller-gen don't work with this golang version
-        CONTROLLER_GEN_VERSION: "v0.16.5"
-        # Need to override this because newer versions of controller-gen don't work with this golang version
-        DLV_VERSION: "v1.25.2"
-      tags:
-        - okteto/golang:1.23
-        - ghcr.io/okteto/golang:1.23

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -25,5 +25,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 WORKDIR /usr/src/app
 
+
+# setup okteto message
 COPY bashrc /root/.bashrc
 CMD ["bash"]

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,24 +1,29 @@
-ARG VERSION="1.24.6"
+ARG VERSION="1.25.5"
 ARG DEBIAN_VERSION="bookworm"
-FROM golang:${VERSION}-${DEBIAN_VERSION} as build
+FROM golang:${VERSION}-${DEBIAN_VERSION}
 
-ARG CONTROLLER_GEN_VERSION="v0.17.3"
+ARG CONTROLLER_GEN_VERSION="v0.20.0"
 ARG DLV_VERSION="v1.26.0"
-ARG AIR_VERSION="v1.61.5"
+ARG AIR_VERSION="v1.63.4"
 ARG GOPLS_VERSION="v0.21.0"
+ARG GIN_VERSION="v0.0.0-20230218063734-2c98d96c9244"
 
 # buildx provides these automatically for multi-arch
 ARG TARGETARCH
 
-RUN go install github.com/codegangsta/gin@latest && \
-    go install github.com/go-delve/delve/cmd/dlv@${DLV_VERSION} && \
-    go install golang.org/x/tools/gopls@${GOPLS_VERSION} && \
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} && \
-    curl -fsSL "https://github.com/air-verse/air/releases/download/${AIR_VERSION}/air_${AIR_VERSION#v}_linux_${TARGETARCH}.tar.gz" | tar -xz -C /usr/local/bin air
+ENV GOBIN=/usr/local/bin
+ENV PATH="/usr/local/bin:${PATH}"
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    set -eux; \
+    go install github.com/codegangsta/gin@${GIN_VERSION}; \
+    go install github.com/go-delve/delve/cmd/dlv@${DLV_VERSION}; \
+    go install golang.org/x/tools/gopls@${GOPLS_VERSION}; \
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}; \
+    curl -fsSL "https://github.com/cosmtrek/air/releases/download/${AIR_VERSION}/air_${AIR_VERSION#v}_linux_${TARGETARCH}.tar.gz" | tar -xz -C /usr/local/bin air
 
 WORKDIR /usr/src/app
 
-# setup okteto message
 COPY bashrc /root/.bashrc
-
 CMD ["bash"]


### PR DESCRIPTION
need golang1.25 for a demo I'm building for a prospect. 

ran into a few friction points, sending the PR in case they are useful for the official image. 
- remove 'latest' in favor of pinned versions  (helps with caching)
-  fixed keyword casing (removed an annoying warning)
- added buildkit caches (mostly useful for when building locally)
- install air's binary instead of building (building it takes a long time on my local machine)